### PR TITLE
travis-ci: build kernel module in various environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,41 @@
 language: c
 
-sudo: false
-
 compiler:
   - gcc
 
-addons:
-  apt:
-    sources:
-    packages:
-
-script:
- - make -C driver check
+jobs:
+  include:
+  - name: 'Run linux kernel checkpatch.pl script'
+    script: make -C driver check
+  - name: 'Build kernel module with linux-4.4.0 headers'
+    arch: amd64
+    dist: xenial
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.4.0-184-generic
+    script:
+    - KERNEL_VERSION=4.4.0-184-generic KERNEL_HAS_PARPORT=1 make -C driver
+  - name: 'Build kernel module with linux-4.4.0 headers'
+    arch: arm64
+    dist: xenial
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.4.0-184-generic
+    script:
+    - KERNEL_VERSION=4.4.0-184-generic KERNEL_HAS_PARPORT=1 make -C driver
+  - name: 'Build kernel module with linux-4.15.0 headers'
+    arch: amd64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.15.0-106-generic
+    script:
+    - KERNEL_VERSION=4.15.0-106-generic KERNEL_HAS_PARPORT=1 make -C driver
+  - name: 'Build kernel module with linux-4.15.0 headers'
+    arch: arm64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.15.0-106-generic
+    script:
+    - KERNEL_VERSION=4.15.0-106-generic KERNEL_HAS_PARPORT=1 make -C driver

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -3,7 +3,10 @@ KERNEL_PATH ?= /lib/modules/$(KERNEL_VERSION)/build
 
 ccflags-y = -DCONFIG_PARPORT_NOT_PC -DCONFIG_PARPORT_1284
 
+ifndef KERNEL_HAS_PARPORT
 obj-m += parport/
+endif
+
 obj-m += parport_gpio.o
 
 all: modules


### PR DESCRIPTION
Existing travis config was only running the `checkpatch.pl` script.  Pull in travis config from sbig-parport that builds the kernel module with 2x2 build matrix.