### PR TITLE
Improve kernel portability and add ID EEPROM DT overlay support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,19 @@ jobs:
     - sudo apt-get -y install linux-headers-4.15.0-106-generic
     script:
     - KERNEL_VERSION=4.15.0-106-generic KERNEL_HAS_PARPORT=1 make -C driver
+  - name: 'Build kernel module with linux-5.4.0 headers'
+    arch: amd64
+    dist: focal
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-5.4.0-52-generic
+    script:
+    - KERNEL_VERSION=5.4.0-52-generic KERNEL_HAS_PARPORT=1 make -C driver
+  - name: 'Build kernel module with linux-5.4.0 headers'
+    arch: arm64
+    dist: focal
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-5.4.0-52-generic
+    script:
+    - KERNEL_VERSION=5.4.0-52-generic KERNEL_HAS_PARPORT=1 make -C driver

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Then reboot the pi to pick up the new config.
 After rebooting, load the base modules:
 ```console
 $ cd ${TOPDIR}
-$ sudo insmod parport/parport.ko
-$ sudo insmod parport_gpio.ko
+$ sudo insmod driver/parport/parport.ko
+$ sudo insmod driver/parport_gpio.ko
 ```
 You'll see the port announce itself on the console:
 ```console

--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ the parport driver stack.  If your application is a printer, go for it.
 ### Building the driver
 
 For convenience, the generic parport code is duplicated in this repo,
-since the Raspberry Pi Foundation does not ship the compiled modules in
-the `raspberrypi-kernel` package.
+since the Raspberry Pi Foundation does not ship the compiled modules
+in the `raspberrypi-kernel` package (at least in old Raspbian
+versions).  If you are intending to use a specific old version of
+Raspbian, there is the shell script `get_parport_src.sh` to assist
+you in getting the code from that particular version.
 
 Clone this repo, then run the following with `${TOPDIR}` representing the
 top level directory of the cloned repo:

--- a/README.md
+++ b/README.md
@@ -83,15 +83,30 @@ $ cd ${TOPDIR}/dts
 $ make
 $ sudo make install
 ```
-then add the following line to `/boot/config.txt`:
+The ID EEPROM stores the name of the DT Overlay to use, and the 
+corresponding DT Overlay will be automatically loaded on boot.  If you 
+will not be using an ID EEPROM, then add the following line to 
+`/boot/config.txt`:
 ```
 dtoverlay=parport-gpio
 ```
 Then reboot the pi to pick up the new config.
 
+### Installing the Modules
+
+Install the modules to allow Linux Device Tree to automatically load
+them.
+```console
+$ cd ${TOPDIR}/driver
+$ sudo make install
+```
+Note that you will need to rebuild and reinstall the modules when you 
+update your kernel version.
+
 ### Loading the Modules
 
-After rebooting, load the base modules:
+If you did not install the modules, after rebooting, load the base 
+modules like this:
 ```console
 $ cd ${TOPDIR}
 $ sudo insmod driver/parport/parport.ko
@@ -129,6 +144,10 @@ the board.
 
 Populating the EEPROM and associated components on a board you're making
 yourself is optional.
+
+Check out the [tests](tests/) directory for some simple "smoke tests"
+on your assembled pi-parport board before attaching your more
+expensive equipment.
 
 Schematics and design files for [previous versions](hardware/)
 are still available for reference.

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,5 +1,6 @@
 KERNEL_VERSION ?= $(shell uname -r)
 KERNEL_PATH ?= /lib/modules/$(KERNEL_VERSION)/build
+MODDIR=/lib/modules/`uname -r`
 
 ccflags-y = -DCONFIG_PARPORT_NOT_PC -DCONFIG_PARPORT_1284
 
@@ -12,7 +13,12 @@ obj-m += parport_gpio.o
 all: modules
 
 modules clean:
-	make -C $(KERNEL_PATH) M=$(shell pwd) $@
+	$(MAKE) -C $(KERNEL_PATH) M=$(shell pwd) $@
 
 check:
 	scripts/checkpatch.pl --no-tree -f parport_gpio.c
+
+install:
+	mkdir -p $(MODDIR)/pi-parport
+	install -m 644 parport_gpio.ko $(MODDIR)/pi-parport
+	$(MAKE) -C parport install

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -16,7 +16,8 @@ modules clean:
 	$(MAKE) -C $(KERNEL_PATH) M=$(shell pwd) $@
 
 check:
-	scripts/checkpatch.pl --no-tree -f parport_gpio.c
+	scripts/checkpatch.pl --ignore=LINUX_VERSION_CODE \
+	  --no-tree -f parport_gpio.c
 
 install:
 	mkdir -p $(MODDIR)/pi-parport

--- a/driver/get_parport_src.sh
+++ b/driver/get_parport_src.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+# Note that we use a custom Makefile to build these files together.
+# mkdir parport/
+
+KSRC_VER=`dpkg -s raspberrypi-kernel | grep Version | cut -d' ' -f2`
+BRANCH=raspberrypi-kernel_$KSRC_VER
+git clone --depth 1 --single-branch --branch $BRANCH --no-checkout \
+  https://github.com/raspberrypi/linux.git
+cd linux
+git show $BRANCH:include/linux/parport.h >../parport/parport.h
+for FILE in daisy.c ieee1284.c ieee1284_ops.c probe.c procfs.c share.c; do
+  git show $BRANCH:drivers/parport/$FILE >../parport/$FILE
+done
+for FILE in lp.c ppdev.c; do
+  git show $BRANCH:drivers/char/$FILE >../parport/$FILE
+done
+cd ..
+# rm -rf linux

--- a/driver/parport/Makefile
+++ b/driver/parport/Makefile
@@ -1,5 +1,6 @@
 KERNEL_VERSION ?= $(shell uname -r)
 KERNEL_PATH ?= /lib/modules/$(KERNEL_VERSION)/build
+MODDIR=/lib/modules/`uname -r`
 
 ccflags-y = -DCONFIG_PARPORT_NOT_PC -DCONFIG_PARPORT_1284
 
@@ -11,3 +12,7 @@ all: modules
 
 modules clean:
 	make -C $(KERNEL_PATH) M=$(shell pwd) $@
+
+install:
+	mkdir -p $(MODDIR)/pi-parport/parport
+	install -m 644 lp.ko parport.ko ppdev.ko $(MODDIR)/pi-parport/parport

--- a/eeprom/Makefile
+++ b/eeprom/Makefile
@@ -1,11 +1,24 @@
 CHIP=24c32
 ADDRESS=50
 I2C_BUS=0
+EMBED_DTBO=0
+VERSION=0x0004
 
 all: board.eep
 
-board.eep: board.txt
-	eepmake $< $@
+board.txt: board.txt.in
+	sed -e '/product_ver/c\product_ver $(VERSION)' $< >$@
+
+ifeq ($(EMBED_DTBO),1)
+overlay.bin: ../dts/parport-gpio.dtbo
+		cp $< $@
+else
+overlay.bin: overlay_name.txt
+		cp $< $@
+endif
+
+board.eep: board.txt overlay.bin
+	eepmake board.txt $@ overlay.bin
 
 flash: board.eep
 	sudo eepflash.sh -w -f=$< -t=$(CHIP) -d=$(I2C_BUS) -a=$(ADDRESS)
@@ -18,4 +31,4 @@ verify:
 	@echo "uuid:        $(shell cat /proc/device-tree/hat/uuid)"
 
 clean:
-	rm -f board.eep
+	rm -f board.txt overlay.bin board.eep

--- a/eeprom/README.md
+++ b/eeprom/README.md
@@ -40,12 +40,15 @@ $ sudo cp eepflash.sh eepdump eepmake /usr/local/bin/
 
 Back in this directory, make the image and flash the chip:
 ```console
-$ make
-eepmake board.txt board.eep
+$ make VERSION=0x0004
+eepmake board.txt board.eep overlay_name.txt
 Opening file board.txt for read
 UUID=3691bbab-1f52-42c7-9cac-01fc81d12688
 Done reading
+Opening DT file overlay_name.txt for read
+Adding 13 bytes of DT data
 Writing out...
+Writing out DT...
 Done.
 $ make flash
 sudo eepflash.sh -w -f=board.eep -t=24c32 -d=0 -a=50
@@ -59,6 +62,11 @@ Writing...
 Closing EEPROM Device.
 Done.
 ```
+Please note: Earlier versions of Raspbian are not compatible with the
+method of storing the name of the DT Overlay in EEPROM, they only
+support a DT Overlay embedded directly.  So, if you wish to use
+pi-parport with one of these, add `EMBED_DTBO=1` to the make command
+line.
 
 Edit `/boot/config.txt`, removing the line added above, then reboot.
 Then, again from this directory, run:

--- a/eeprom/board.txt.in
+++ b/eeprom/board.txt.in
@@ -22,7 +22,7 @@ product_uuid 00000000-0000-0000-0000-000000000000
 product_id 0x0001
 
 # 16 bit product version
-product_ver 0x0003
+product_ver 0x0004
 
 # ASCII vendor string  (max 255 characters)
 vendor "WorlickWerx"

--- a/eeprom/overlay_name.txt
+++ b/eeprom/overlay_name.txt
@@ -1,0 +1,1 @@
+parport-gpio


### PR DESCRIPTION
Summary of changes:

* Add a shell script to assist in fetching the parport drivers for a specific older version of Linux, document in README.  Useful for vintage fans if they have a preference toward a specific older version of Linux.

* Parameterize the version in the EEPROM, add README documentation for using an ID EEPROM to automatically load the drivers when the pi-parport board is attached.

* Update gpiod function contract fixes to conditionally check the version of Linux and use the corresponding function contract.  I wasn't sure which Linux version made the change, so I just put in the latest version.

* Other small, helpful changes to READMEs throughout.

* Add Linux 5.4.0 build to Travis CI.