### PR TITLE
hardware: Add DIP jumper to BOM.

### DIFF
--- a/hardware/v3/BOM.md
+++ b/hardware/v3/BOM.md
@@ -23,10 +23,11 @@ is listed here, though it cannot be used yet.
 | -------- | --------- | ------------------- | ---------------- | ------------------------------- | --------------------------- | ----------------------------------------- | ------------------------------------------------ |
 | 1        | C1        | 399-1177-1-ND       | C0805C104Z5VACTU | KEMET                           | 0805                        | 100nF, 50V capacitor                      | Bypass                                           |
 
-Additional board mounting and connector components:
+Additional board components, depends on needs:
 
 | Quan | Description | Supplier | Notes |
 | ---- | ----------- | -------- | ----- |
+| 1    | DIP jumper  | [Digi-Key](https://www.digikey.com/en/products/detail/sullins-connector-solutions/QPC02SXGN-RC/2618262) |       |
 | 4    | M2.5 x 16mm brass standoff, with M2.5 nut | [Adafruit](https://www.adafruit.com/product/2336) | pi HAT standoff (height 11mm) |
 | 4    | M2.5 x 6mm philips head screw |    |    |
 | 1    | Female DB25 to female 13x2 header cable assembly | [Amazon](https://www.amazon.com/Motherboard-Parallel-Printer-bracket-socket/dp/B00PI5XF4U) | or surplus |

--- a/hardware/v4/BOM.md
+++ b/hardware/v4/BOM.md
@@ -16,10 +16,11 @@ shipment.
 | 1        | U2        | 296-8467-5-ND       | SN74LVC161284DL  | Texas Instruments               | 48-SSOP (0.64mm lead pitch) | 19-bit bus interface with 3-state outputs | pin 1 marking oriented opposite J3               |
 | 2        | C1 C2     | 399-1177-1-ND       | C0805C104Z5VACTU | KEMET                           | 0805                        | 100nF, 50V capacitor                      | Bypass                                           |
 
-Additional board mounting and connector components:
+Additional board components, depends on needs:
 
 | Quan | Description | Supplier | Notes |
 | ---- | ----------- | -------- | ----- |
+| 1    | DIP jumper  | [Digi-Key](https://www.digikey.com/en/products/detail/sullins-connector-solutions/QPC02SXGN-RC/2618262) |       |
 | 4    | M2.5 x 16mm brass standoff, with M2.5 nut | [Adafruit](https://www.adafruit.com/product/2336) | pi HAT standoff (height 11mm) |
 | 4    | M2.5 x 6mm philips head screw |    |    |
 | 1    | Female DB25 to female 13x2 header cable assembly | [Amazon](https://www.amazon.com/Motherboard-Parallel-Printer-bracket-socket/dp/B00PI5XF4U) | or surplus |


### PR DESCRIPTION
Add DIP jumper to BOM to facilitate possible planning for a pi-parport kit offering as discussed in #48.