### PR TITLE
driver, eeprom: Fix driver install issue, note on i2c-dev for EEPROM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ them.
 $ cd ${TOPDIR}/driver
 $ sudo make install
 ```
-Note that you will need to rebuild and reinstall the modules when you
-update your kernel version.
+Note that only the `parport` and `parport_gpio` base modules will
+autoload, the `ppdev` and `lp` modules will still need to be specified
+in `/etc/modules` or otherwise.  Also, note that you will need to
+rebuild and reinstall the modules when you update your kernel version.
 
 ### Loading the Modules
 
@@ -160,7 +162,7 @@ the board.
 Populating the EEPROM and associated components on a board you're making
 yourself is optional.
 
-Check out the [tests](tests/) directory for some simple "smoke tests"
+Check out the [test](test/) directory for some simple "smoke tests"
 on your assembled pi-parport board before attaching your more
 expensive equipment.
 

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -23,7 +23,9 @@ install: parport_gpio.ko
 	mkdir -p $(MODDIR)/pi-parport
 	install -m 644 $^ $(MODDIR)/pi-parport
 	$(MAKE) -C parport install
+	depmod
 
 uninstall:
 	$(MAKE) -C parport uninstall
 	rm -rf $(MODDIR)/pi-parport
+	depmod

--- a/eeprom/README.md
+++ b/eeprom/README.md
@@ -3,6 +3,12 @@
 Install J1 (or solder a zero-ohm resistor in R1) to defeat EEPROM
 write protect.
 
+To use and program your EEPROM, ensure that `/etc/modules` contains
+`i2c-dev`.  This is normally the case if you have a full installation
+of Raspbian, but if you've opted for a lite installation or a
+different operating system, this line might be missing.  Add it and
+ensure the module is loaded by typing `sudo modprobe i2c-dev`.
+
 Edit `/boot/config.txt`, adding this line temporarily so the ID bus is visible
 after boot, and reboot:
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -2,6 +2,8 @@
 
 These tests primarily check that the bits aren't shorted, open,
 or misrouted, and the the DTS overlay is properly configured.
+Ensure that the `ppdev` module is loaded before running these
+tests.
 
 ### loop - plug A
 


### PR DESCRIPTION
This pull request is some of the real fixes to issue #47.  Our driver install script and documentation needed some improvements.