### PR TITLE
ci: drop ubuntu 16.04 test, add driver load test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,30 @@ jobs:
         fetch-depth: 0
     - name: build driver
       run: KERNEL_VERSION=4.15.0-106-generic KERNEL_HAS_PARPORT=1 make -C driver
+
+  load-driver-latest:
+    name: build driver against running kernel and load it
+    runs-on: ubuntu-20.04
+    steps:
+    - name: install libelf-dev
+      run: sudo apt-get -y install libelf-dev
+    - name: install linux-headers
+      run: sudo apt-get install linux-headers-$(uname -r)
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: build driver
+      run: KERNEL_HAS_PARPORT=1 make -C driver
+    - name: clear kernel log messages
+      run: sudo dmesg --clear
+    - name: load dependent kernel modules
+      run: sudo modprobe parport
+    - name: load driver
+      run: sudo insmod driver/parport_gpio.ko \
+    - name: print kernel log messages
+      if: always()
+      run: sudo dmesg
+    - name: unload kernel modules
+      if: always()
+      run: sudo rmmod parport_gpio parport

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,18 +53,3 @@ jobs:
         fetch-depth: 0
     - name: build driver
       run: KERNEL_VERSION=4.15.0-106-generic KERNEL_HAS_PARPORT=1 make -C driver
-
-  build-driver-4-4:
-    name: build driver against linux-4.4
-    runs-on: ubuntu-16.04
-    steps:
-    - name: install libelf-dev
-      run: sudo apt-get -y install libelf-dev
-    - name: install linux-headers
-      run: sudo apt-get install linux-headers-4.4.0-184-generic
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
-    - name: build driver
-      run: KERNEL_VERSION=4.4.0-184-generic KERNEL_HAS_PARPORT=1 make -C driver


### PR DESCRIPTION
CI hangs because it is waiting for an available ubuntu-16.04 runner, which is no longer offered by github.  Drop that test.

Add a test that builds against the running ubuntu-latest kernel and loads/unloads the driver.  That might catch some additional problems down the road.