### PR TITLE
ci: drop deprecated ubuntu-18.04 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,21 +39,6 @@ jobs:
     - name: build driver
       run: KERNEL_VERSION=5.4.0-52-generic KERNEL_HAS_PARPORT=1 make -C driver
 
-  build-driver-4-15:
-    name: build driver against linux-4.15
-    runs-on: ubuntu-18.04
-    steps:
-    - name: install libelf-dev
-      run: sudo apt-get -y install libelf-dev
-    - name: install linux-headers
-      run: sudo apt-get install linux-headers-4.15.0-106-generic
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
-    - name: build driver
-      run: KERNEL_VERSION=4.15.0-106-generic KERNEL_HAS_PARPORT=1 make -C driver
-
   load-driver-latest:
     name: build driver against running kernel and load it
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Problem: github has deprecated the ubuntu-18.04 runner

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Drop ci testing of linux-4.15 that uses this builder.