### PR TITLE
ci: add kicad ERC/DRC checks for v5 hardawre

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,3 +65,31 @@ jobs:
     - name: unload kernel modules
       if: always()
       run: sudo rmmod parport_gpio parport
+
+  check-hardware-v5:
+    name: check v5 hardware
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo add-apt-repository --yes ppa:kicad/kicad-8.0-releases
+        sudo apt-get update
+        sudo apt-get install -y \
+            make \
+            kicad=8.0.5*
+    - name: initialize kicad config
+      run: |
+        mkdir -p $HOME/.config/kicad/8.0
+        cp /usr/share/kicad/template/fp-lib-table $HOME/.config/kicad/8.0/
+        cp /usr/share/kicad/template/sym-lib-table $HOME/.config/kicad/8.0/
+    - name: display kicad version
+      run: |
+        echo "Kicad:"
+        kicad-cli --version
+    - name: ERC
+      run: |
+        make -C hardware/v5 check_erc
+    - name: DRC
+      run: |
+        make -C hardware/v5 check_drc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -17,7 +17,7 @@ jobs:
     name: kernel style check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -32,7 +32,7 @@ jobs:
       run: sudo apt-get -y install libelf-dev
     - name: install linux-headers
       run: sudo apt-get install linux-headers-5.4.0-52-generic
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
       run: sudo apt-get -y install libelf-dev
     - name: install linux-headers
       run: sudo apt-get install linux-headers-$(uname -r)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
     name: check v5 hardware
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo add-apt-repository --yes ppa:kicad/kicad-8.0-releases

--- a/hardware/scripts/run_drc.sh
+++ b/hardware/scripts/run_drc.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+kicad-cli pcb drc \
+    -o pcb_drc.rpt \
+    --exit-code-violations \
+    --severity-all \
+    $DRC_INPUT
+result=$?
+test $result -eq 0 || cat pcb_drc.rpt >&2
+exit $result

--- a/hardware/scripts/run_erc.sh
+++ b/hardware/scripts/run_erc.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+kicad-cli sch erc \
+    -o sch_erc.rpt \
+    --exit-code-violations \
+    --severity-all \
+    $ERC_INPUT
+result=$?
+test $result -eq 0 || cat sch_erc.rpt >&2
+exit $result

--- a/hardware/v5/Makefile
+++ b/hardware/v5/Makefile
@@ -1,0 +1,8 @@
+all:
+
+check: check_erc check_drc
+
+check_erc: hat.kicad_sch
+	ERC_INPUT=$< ../scripts/run_erc.sh
+check_drc: hat.kicad_pcb
+	DRC_INPUT=$< ../scripts/run_drc.sh


### PR DESCRIPTION
Problem: it's too easy to commit kicad changes with errors.

Create a github action that runs ERC and DRC checks via `kicad-cli`.  This should flag any problems with PRs and make the approval process a little easier.