### PR TITLE
add scripts to produce JLCPCB manufacturing files

### DIFF
--- a/hardware/scripts/make_bom.sh
+++ b/hardware/scripts/make_bom.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Generate bill of materials for JLCPCB assembly per
+# https://jlcpcb.com/help/article/How-to-generate-the-BOM-and-Centroid-file-from-KiCAD
+
+if test $# -ne 2; then
+    echo "Usage $(basename $0) schfile bomfile" >&2
+    exit 1
+fi
+schfile=$(realpath $1)
+bomfile=$2
+
+kicad-cli sch export bom \
+       --output=$bomfile \
+       --fields='Comment,Reference,Footprint,LCSC,Mouser' \
+       --labels='Comment,Designator,Footprint,LCSC,Mouser' \
+       --string-delimiter= \
+       --sort-field=Reference \
+       --group-by=Comment \
+       --ref-delimiter=' ' \
+       --ref-range-delimiter= \
+       --exclude-dnp \
+       $schfile

--- a/hardware/scripts/make_pos.sh
+++ b/hardware/scripts/make_pos.sh
@@ -1,0 +1,30 @@
+#!/bin/sh -e
+
+# generate pick and place file for JLCPCB assembly per
+# https://jlcpcb.com/help/article/How-to-generate-the-BOM-and-Centroid-file-from-KiCAD
+
+if test $# -ne 3; then
+    echo "Usage $(basename $0) pcbfile posfile front|back" >&2
+    exit 1
+fi
+pcbfile=$(realpath $1)
+posfile=$2
+side=$3
+
+
+kicad-cli pcb export pos \
+	--output=$posfile \
+	--format=csv \
+	--smd-only \
+	--exclude-dnp \
+	--units=mm \
+	--side=$side \
+	$pcbfile
+
+sed --in-place \
+	-e 's/Ref,/Designator,/' \
+	-e 's/PosX,/Mid X,/' \
+	-e 's/PosY,/Mid Y,/' \
+	-e 's/Rot,/Rotation,/' \
+	-e 's/Side$/Layer/' \
+	$posfile

--- a/hardware/scripts/plot.sh
+++ b/hardware/scripts/plot.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Generate gerbers for JLCPCB per
+# https://jlcpcb.com/help/article/362-how-to-generate-gerber-and-drill-files-in-kicad-7
+
+die() {
+    echo $* >&2
+    exit 1
+}
+
+if test $# -ne 2; then
+    echo "Usage $(basename $0) pcbfile zipfile" >&2
+    exit 1
+fi
+pcbfile=$(realpath $1)
+zipfile=$2
+
+tmpdir=$(mktemp -d) || die "could not create output directory"
+
+pushd $tmpdir
+    kicad-cli pcb export gerbers \
+	--layers=F.Cu,B.Cu,F.Paste,B.Paste,F.Silkscreen,B.Silkscreen,F.Mask,B.Mask,Edge.Cuts,F.Fab,B.Fab \
+	--subtract-soldermask \
+	--no-x2 \
+	$pcbfile
+    test $? -eq 0 || die "could not export gerber files"
+    rm -f *.gbrjob
+
+    kicad-cli pcb export drill \
+	--format=excellon \
+	--excellon-separate-th \
+	--excellon-oval-format=alternate \
+	--map-format=ps \
+	--drill-origin=absolute \
+	--excellon-units=mm \
+	--excellon-zeros-format=decimal \
+	$pcbfile
+    test $? -eq 0 || die "could not export drill files"
+popd
+
+echo Generating $zipfile
+find $tmpdir -type f -print | zip --quiet --junk-paths $zipfile -@
+test $? -eq 0 || die "error creating zip archive"
+rm -rf $tmpdir

--- a/hardware/scripts/run_drc.sh
+++ b/hardware/scripts/run_drc.sh
@@ -4,7 +4,7 @@ kicad-cli pcb drc \
     -o pcb_drc.rpt \
     --exit-code-violations \
     --severity-all \
-    $DRC_INPUT
+    $1
 result=$?
 test $result -eq 0 || cat pcb_drc.rpt >&2
 exit $result

--- a/hardware/scripts/run_erc.sh
+++ b/hardware/scripts/run_erc.sh
@@ -4,7 +4,7 @@ kicad-cli sch erc \
     -o sch_erc.rpt \
     --exit-code-violations \
     --severity-all \
-    $ERC_INPUT
+    $1
 result=$?
 test $result -eq 0 || cat sch_erc.rpt >&2
 exit $result

--- a/hardware/v5/Makefile
+++ b/hardware/v5/Makefile
@@ -3,6 +3,9 @@ all:
 check: check_erc check_drc
 
 check_erc: hat.kicad_sch
-	ERC_INPUT=$< ../scripts/run_erc.sh
+	../scripts/run_erc.sh $<
 check_drc: hat.kicad_pcb
-	DRC_INPUT=$< ../scripts/run_drc.sh
+	../scripts/run_drc.sh $<
+
+clean:
+	rm -f *.rpt

--- a/hardware/v5/Makefile
+++ b/hardware/v5/Makefile
@@ -1,4 +1,4 @@
-all:
+all: cam.zip bom.csv pos_top.csv
 
 cam.zip: hat.kicad_pcb
 	../scripts/plot.sh $< $@

--- a/hardware/v5/Makefile
+++ b/hardware/v5/Makefile
@@ -2,6 +2,8 @@ all:
 
 bom.csv: hat.kicad_sch
 	../scripts/make_bom.sh $< $@
+pos_top.csv: hat.kicad_pcb
+	../scripts/make_pos.sh $< $@ front
 
 check: check_erc check_drc
 
@@ -13,3 +15,4 @@ check_drc: hat.kicad_pcb
 clean:
 	rm -f *.rpt
 	rm -f bom.csv
+	rm -f pos_top.csv

--- a/hardware/v5/Makefile
+++ b/hardware/v5/Makefile
@@ -1,5 +1,8 @@
 all:
 
+bom.csv: hat.kicad_sch
+	../scripts/make_bom.sh $< $@
+
 check: check_erc check_drc
 
 check_erc: hat.kicad_sch
@@ -9,3 +12,4 @@ check_drc: hat.kicad_pcb
 
 clean:
 	rm -f *.rpt
+	rm -f bom.csv

--- a/hardware/v5/Makefile
+++ b/hardware/v5/Makefile
@@ -1,5 +1,8 @@
 all:
 
+cam.zip: hat.kicad_pcb
+	../scripts/plot.sh $< $@
+
 bom.csv: hat.kicad_sch
 	../scripts/make_bom.sh $< $@
 pos_top.csv: hat.kicad_pcb
@@ -16,3 +19,4 @@ clean:
 	rm -f *.rpt
 	rm -f bom.csv
 	rm -f pos_top.csv
+	rm -f cam.zip

--- a/hardware/v5/hat.kicad_pro
+++ b/hardware/v5/hat.kicad_pro
@@ -529,25 +529,37 @@
     },
     "bom_presets": [],
     "bom_settings": {
-      "exclude_dnp": false,
+      "exclude_dnp": true,
       "fields_ordered": [
         {
           "group_by": false,
-          "label": "Reference",
-          "name": "Reference",
+          "label": "Do Not Place",
+          "name": "${DNP}",
           "show": true
         },
         {
           "group_by": true,
+          "label": "Comment",
+          "name": "Comment",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Designator",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": false,
           "label": "Value",
           "name": "Value",
-          "show": true
+          "show": false
         },
         {
           "group_by": false,
           "label": "Datasheet",
           "name": "Datasheet",
-          "show": true
+          "show": false
         },
         {
           "group_by": false,
@@ -557,20 +569,38 @@
         },
         {
           "group_by": false,
+          "label": "Description",
+          "name": "Description",
+          "show": false
+        },
+        {
+          "group_by": false,
           "label": "Qty",
           "name": "${QUANTITY}",
+          "show": false
+        },
+        {
+          "group_by": false,
+          "label": "#",
+          "name": "${ITEM_NUMBER}",
+          "show": false
+        },
+        {
+          "group_by": false,
+          "label": "LCSC",
+          "name": "LCSC",
           "show": true
         },
         {
-          "group_by": true,
-          "label": "DNP",
-          "name": "${DNP}",
+          "group_by": false,
+          "label": "Mouser",
+          "name": "Mouser",
           "show": true
         }
       ],
       "filter_string": "",
       "group_symbols": true,
-      "name": "Grouped By Value",
+      "name": "",
       "sort_asc": true,
       "sort_field": "Reference"
     },

--- a/hardware/v5/hat.kicad_sch
+++ b/hardware/v5/hat.kicad_sch
@@ -8076,6 +8076,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "Harwin M20-7812045 or equiv"
+			(at 57.15 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 57.15 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "855-M20-7812045"
+			(at 57.15 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "8d678796-43d4-427f-808d-7fd8ec169db6")
 		)
@@ -8322,6 +8349,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "100nF 25V MLCC"
+			(at 67.31 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C346189"
+			(at 67.31 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 67.31 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "e13b4ec0-0b1a-4833-a57f-adf38fe98aef")
 		)
@@ -8383,6 +8437,33 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
+			(at 180.34 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" "100nF 25V MLCC"
+			(at 180.34 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C346189"
+			(at 180.34 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
 			(at 180.34 49.53 0)
 			(effects
 				(font
@@ -8460,6 +8541,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "3K9 100mW 1%"
+			(at 93.98 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C144659"
+			(at 93.98 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 93.98 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "c26b8bce-ef1b-44c3-8d6f-bdc9a8551c9b")
 		)
@@ -8528,38 +8636,29 @@
 				(hide yes)
 			)
 		)
-		(property "Digi-Key_PN" "296-8467-5-ND"
-			(at 170.18 76.2 0)
+		(property "Comment" "SN74LVC161284DLR"
+			(at 198.12 87.63 0)
 			(effects
 				(font
-					(size 1.524 1.524)
+					(size 1.27 1.27)
 				)
 				(hide yes)
 			)
 		)
-		(property "MPN" "SN74LVC161284DL"
-			(at 170.18 76.2 0)
+		(property "LCSC" ""
+			(at 198.12 87.63 0)
 			(effects
 				(font
-					(size 1.524 1.524)
+					(size 1.27 1.27)
 				)
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" "Texas Instruments"
-			(at 170.18 76.2 0)
+		(property "Mouser" "595-SN74LVC161284DLR"
+			(at 198.12 87.63 0)
 			(effects
 				(font
-					(size 1.524 1.524)
-				)
-				(hide yes)
-			)
-		)
-		(property "Package" "48-SSOP"
-			(at 170.18 76.2 0)
-			(effects
-				(font
-					(size 1.524 1.524)
+					(size 1.27 1.27)
 				)
 				(hide yes)
 			)
@@ -8772,6 +8871,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "1K4 100mW 1%"
+			(at 170.18 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C705740"
+			(at 170.18 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 170.18 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "255e1419-baf8-40d8-ac48-f671d17821a8")
 		)
@@ -8833,6 +8959,33 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
+			(at 128.27 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" "100nF 25V MLCC"
+			(at 128.27 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C346189"
+			(at 128.27 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
 			(at 128.27 49.53 0)
 			(effects
 				(font
@@ -8910,6 +9063,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "100nF 25V MLCC"
+			(at 190.5 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C346189"
+			(at 190.5 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 190.5 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "ebfaadbc-1d27-45c9-a416-49bbbab650e0")
 		)
@@ -8932,7 +9112,7 @@
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
-		(dnp no)
+		(dnp yes)
 		(uuid "43e66c4c-de75-44f8-8171-19825b035cbb")
 		(property "Reference" "JP1"
 			(at 96.52 183.623 0)
@@ -8970,6 +9150,33 @@
 			)
 		)
 		(property "Description" "Solder Jumper, 2-pole, open"
+			(at 96.52 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" ""
+			(at 96.52 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 96.52 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
 			(at 96.52 180.34 0)
 			(effects
 				(font
@@ -9102,6 +9309,33 @@
 			)
 		)
 		(property "Description" "Resistor, small symbol"
+			(at 101.6 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" "3K9 100mW 1%"
+			(at 101.6 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C144659"
+			(at 101.6 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
 			(at 101.6 170.18 0)
 			(effects
 				(font
@@ -9373,6 +9607,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "CAT24C256WI-GT3"
+			(at 81.28 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C79987"
+			(at 81.28 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 81.28 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "4a4c04f8-9fad-44aa-b889-3ba05bfe1829")
 		)
@@ -9460,6 +9721,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" "100nF 25V MLCC"
+			(at 118.11 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C346189"
+			(at 118.11 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 118.11 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "2e607fca-f11f-4495-b9c5-537f1a9adb24")
 		)
@@ -9522,6 +9810,33 @@
 			)
 		)
 		(property "Description" "Generic connectable mounting pin connector, single row, 01x04, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 59.69 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" "JST SM04-SRSS-TB"
+			(at 59.69 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 59.69 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "306-SM04BSRSSTBLFSNP"
 			(at 59.69 130.81 0)
 			(effects
 				(font
@@ -9949,7 +10264,7 @@
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
-		(dnp no)
+		(dnp yes)
 		(fields_autoplaced yes)
 		(uuid "c59fef1e-da13-4018-9f46-115bc2e92dfd")
 		(property "Reference" "J4"
@@ -9997,6 +10312,33 @@
 				(hide yes)
 			)
 		)
+		(property "Comment" ""
+			(at 147.32 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 147.32 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
+			(at 147.32 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "3"
 			(uuid "529509c6-9669-42db-9006-704322e1a658")
 		)
@@ -10022,7 +10364,7 @@
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
-		(dnp no)
+		(dnp yes)
 		(fields_autoplaced yes)
 		(uuid "c94a9655-5841-4ada-bd09-9f30d82785a6")
 		(property "Reference" "J3"
@@ -10060,6 +10402,33 @@
 			)
 		)
 		(property "Description" "Generic connector, double row, 02x13, top/bottom pin numbering scheme (row 1: 1...pins_per_row, row2: pins_per_row+1 ... num_pins), script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 236.22 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" ""
+			(at 236.22 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 236.22 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
 			(at 236.22 83.82 0)
 			(effects
 				(font
@@ -10390,6 +10759,33 @@
 			)
 		)
 		(property "Description" "Resistor, small symbol"
+			(at 109.22 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Comment" "1K 100mW 1%"
+			(at 109.22 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C110776"
+			(at 109.22 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" ""
 			(at 109.22 170.18 0)
 			(effects
 				(font


### PR DESCRIPTION
This populates component metadata for the v5 board and adds scripts to generate bom, pick and place, and cam files for JLCPCB.

I thought I'd try a small batch where they stick the SMT parts on for us.  Or at least get it quoted - if it's too expensive then I'll just order some boards to test first.